### PR TITLE
added in email contact form

### DIFF
--- a/healthyplanet/templates/yourpledges.html
+++ b/healthyplanet/templates/yourpledges.html
@@ -16,4 +16,16 @@ Your Pledges - Healthy Planet
 	</div>
 	{% endif %}
 
+<div class="container">
+	<h2>To get an email containing these pledges please enter your name and email address below</h2>
+	<form action="#", method="POST">
+		<label for="fname">First name:</label><br>
+		<input type="text" id="fname" name="fname" placeholder="first name"><br>
+		<label for="email">email:</label><br>
+		<input type="text" id="email" name="email" placeholder="your email"><br><br>
+		<input type="submit" value="Submit">
+	</form> 
+	<br><br>
+</div>
+
 {% endblock %}


### PR DESCRIPTION
user can put details in email form but doesnt go anywhere on submit - getting your pledges page back which is expected as no action set for form to be submitted to, but yourpledges page then renders without a navbar!  Extended to base.html so cant see why that should be.  Do feel free to reject pull request if not happy with it.